### PR TITLE
NfcService: Sync with QPR1 AOSP changes, fix error: cannot find symbol

### DIFF
--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -11,6 +11,8 @@
     <integer name="max_antenna_blocked_failure_count">10</integer>
     <integer name="toast_debounce_time_ms">3000</integer>
     <integer name="unknown_tag_polling_delay">-1</integer>
+    <integer name="unknown_tag_polling_delay_count_max">5</integer>
+    <integer name="unknown_tag_polling_delay_long">30000</integer>
 
     <!-- List of SKUs where Secure NFC functionality is supported -->
     <string-array name="config_skuSupportsSecureNfc" translatable="false" />


### PR DESCRIPTION
vendor/nxp/opensource/commonsys/packages/apps/Nfc/src/com/android/nfc/NfcService.java:940: error: cannot find symbol
                mContext.getResources().getInteger(R.integer.unknown_tag_polling_delay_count_max);
                                                            ^
  symbol:   variable unknown_tag_polling_delay_count_max
  location: class integer
vendor/nxp/opensource/commonsys/packages/apps/Nfc/src/com/android/nfc/NfcService.java:945: error: cannot find symbol
                mContext.getResources().getInteger(R.integer.unknown_tag_polling_delay_long);
                                                            ^
  symbol:   variable unknown_tag_polling_delay_long
  location: class integer
2 errors